### PR TITLE
Uveď kódování při načítání souboru

### DIFF
--- a/vtipnik.py
+++ b/vtipnik.py
@@ -8,7 +8,7 @@ def nacti_vtip(cesta_ke_vtipu):
     tak vrátí text vtipu jako řetězec.
     """
     try:
-        with open(cesta_ke_vtipu, 'r') as f:
+        with open(cesta_ke_vtipu, 'r', encoding="utf-8") as f:
             return f.read()
     except FileNotFoundError:
         sys.exit('Bohuzel soubor s vtipem neexistuje: {}'.format(cesta_ke_vtipu))


### PR DESCRIPTION
Vtipy jsou uložené jako UTF-8. Při [načítání](https://github.com/frenzymadness/vtipnik/compare/master...Glutexo:kodovani?expand=1#diff-b83ab8bc1f1a4c38bc98da44177ec9b5R11) souboru musíme kódování uvést, jinak se nenačte, případně nevypíše správně, pokud má systém nastavené jiné výchozí kódování. To je typicky případ Windows, jak jinak. 🤦🏻‍♂️